### PR TITLE
Add sentiment analysis web app for random reviews

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,216 @@
+const DATA_SOURCE = 'reviews_test.tsv';
+const MODEL_ENDPOINT = 'https://api-inference.huggingface.co/models/siebert/sentiment-roberta-large-english';
+
+const tokenInput = document.getElementById('token-input');
+const analyzeBtn = document.getElementById('analyze-btn');
+const reviewTextEl = document.getElementById('review-text');
+const sentimentDisplayEl = document.getElementById('sentiment-display');
+const sentimentIconEl = document.getElementById('sentiment-icon');
+const sentimentLabelEl = document.getElementById('sentiment-label');
+const statusMessageEl = document.getElementById('status-message');
+const errorMessageEl = document.getElementById('error-message');
+
+let reviews = [];
+let isFetching = false;
+
+function setStatus(message) {
+    statusMessageEl.textContent = message ?? '';
+}
+
+function setError(message) {
+    errorMessageEl.textContent = message ?? '';
+}
+
+function resetSentiment() {
+    sentimentDisplayEl.hidden = true;
+    sentimentIconEl.className = 'sentiment-icon';
+    sentimentIconEl.innerHTML = '';
+    sentimentLabelEl.textContent = '';
+}
+
+async function loadReviews() {
+    if (isFetching || reviews.length) {
+        return;
+    }
+
+    isFetching = true;
+    setStatus('Fetching reviews dataset…');
+    setError('');
+    resetSentiment();
+
+    try {
+        const response = await fetch(DATA_SOURCE, { cache: 'no-cache' });
+        if (!response.ok) {
+            throw new Error(`Failed to load dataset (${response.status} ${response.statusText})`);
+        }
+        const rawText = await response.text();
+
+        Papa.parse(rawText, {
+            header: true,
+            delimiter: '\t',
+            skipEmptyLines: true,
+            complete: (result) => {
+                if (result.errors && result.errors.length) {
+                    console.error('Papa Parse errors:', result.errors);
+                    setError('Unable to read the TSV file. Please try again later.');
+                    setStatus('');
+                    return;
+                }
+
+                reviews = result.data
+                    .map((row) => (row && typeof row.text === 'string' ? row.text.trim() : ''))
+                    .filter((text) => text.length > 0);
+
+                if (!reviews.length) {
+                    setError('No reviews were found in the TSV file.');
+                    setStatus('');
+                    reviewTextEl.textContent = 'Dataset is empty. Add reviews to continue.';
+                    analyzeBtn.disabled = true;
+                    return;
+                }
+
+                reviewTextEl.textContent = 'Click the button to explore a random review.';
+                analyzeBtn.disabled = false;
+                setStatus(`${reviews.length} reviews loaded. Ready when you are!`);
+            },
+            error: (parseError) => {
+                console.error('Papa Parse encountered an error:', parseError);
+                setError('Unable to process the TSV file.');
+                setStatus('');
+            },
+        });
+    } catch (error) {
+        console.error('Dataset fetch failed:', error);
+        setError('Failed to download the dataset. Check your connection and refresh.');
+        setStatus('');
+        reviewTextEl.textContent = 'Unable to load reviews.';
+        analyzeBtn.disabled = true;
+    } finally {
+        isFetching = false;
+    }
+}
+
+function pickRandomReview() {
+    if (!reviews.length) {
+        return null;
+    }
+    const randomIndex = Math.floor(Math.random() * reviews.length);
+    return reviews[randomIndex];
+}
+
+function renderSentiment(classification) {
+    resetSentiment();
+    if (!classification) {
+        return;
+    }
+
+    const { label, iconClass, text } = classification;
+    sentimentIconEl.classList.add(label);
+    const iconElement = document.createElement('i');
+    iconElement.classList.add('fa-solid', iconClass);
+    sentimentIconEl.appendChild(iconElement);
+    sentimentLabelEl.textContent = text;
+    sentimentDisplayEl.hidden = false;
+}
+
+function interpretPrediction(predictions) {
+    if (!Array.isArray(predictions) || !predictions.length) {
+        return null;
+    }
+
+    let entries = predictions;
+    if (Array.isArray(predictions[0])) {
+        entries = predictions[0];
+    }
+
+    entries = entries.filter((entry) => entry && typeof entry.score === 'number' && typeof entry.label === 'string');
+    if (!entries.length) {
+        return null;
+    }
+
+    const topEntry = entries.reduce((best, current) => (current.score > best.score ? current : best));
+    const normalizedLabel = topEntry.label.toUpperCase();
+
+    if (normalizedLabel.includes('POSITIVE') && topEntry.score > 0.5) {
+        return { label: 'positive', iconClass: 'fa-thumbs-up', text: `Positive (${(topEntry.score * 100).toFixed(1)}% confidence)` };
+    }
+    if (normalizedLabel.includes('NEGATIVE') && topEntry.score > 0.5) {
+        return { label: 'negative', iconClass: 'fa-thumbs-down', text: `Negative (${(topEntry.score * 100).toFixed(1)}% confidence)` };
+    }
+
+    return { label: 'neutral', iconClass: 'fa-question', text: 'Neutral or uncertain sentiment' };
+}
+
+async function analyzeReview(review) {
+    const token = tokenInput.value.trim();
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
+    setStatus('Analyzing sentiment…');
+    setError('');
+    resetSentiment();
+    analyzeBtn.disabled = true;
+
+    try {
+        const response = await fetch(MODEL_ENDPOINT, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ inputs: review }),
+        });
+
+        if (!response.ok) {
+            let errorDetails = '';
+            try {
+                const problem = await response.json();
+                errorDetails = problem.error || problem.message || '';
+            } catch (parseErr) {
+                errorDetails = response.statusText;
+            }
+            throw new Error(errorDetails || `API request failed with status ${response.status}`);
+        }
+
+        const data = await response.json();
+        const sentiment = interpretPrediction(data);
+        if (!sentiment) {
+            setError('Received an unexpected response from the model.');
+            setStatus('');
+            return;
+        }
+
+        renderSentiment(sentiment);
+        setStatus('Analysis complete.');
+    } catch (error) {
+        console.error('Sentiment analysis failed:', error);
+        if (error.message && error.message.toLowerCase().includes('rate')) {
+            setError('Rate limit reached. Try again in a moment or provide an API token.');
+        } else if (error.message && error.message.toLowerCase().includes('authorization')) {
+            setError('Authorization failed. Check your token.');
+        } else if (error.message) {
+            setError(error.message);
+        } else {
+            setError('Something went wrong while contacting Hugging Face.');
+        }
+        setStatus('');
+    } finally {
+        analyzeBtn.disabled = false;
+    }
+}
+
+analyzeBtn.addEventListener('click', () => {
+    setError('');
+    const review = pickRandomReview();
+    if (!review) {
+        setError('No reviews available to analyze.');
+        return;
+    }
+    reviewTextEl.textContent = review;
+    analyzeReview(review);
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+    loadReviews();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Random Review Sentiment Explorer</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-kWu7HFLuH1sO3uoCbcnZ6+QcmGeX+z9K/Y/xFdVtOfvtTDHkJ/xZBwbNG0Ax7Anxr1j7rwhhtjfiw2X2W12hNQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #0d1117;
+            --surface: rgba(13, 17, 23, 0.92);
+            --text: #f0f6fc;
+            --accent: #58a6ff;
+            --accent-dark: #1f6feb;
+            --error: #ff6b6b;
+            --neutral: #d29922;
+            --positive: #2ea043;
+            --negative: #f85149;
+            font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: radial-gradient(circle at top, #1f6feb 0%, #0d1117 55%);
+            color: var(--text);
+            padding: 2rem;
+        }
+
+        .card {
+            width: min(680px, 100%);
+            background: rgba(13, 17, 23, 0.85);
+            border: 1px solid rgba(88, 166, 255, 0.2);
+            border-radius: 18px;
+            padding: 2.5rem 2rem;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+            backdrop-filter: blur(12px);
+        }
+
+        h1 {
+            font-size: clamp(1.8rem, 5vw, 2.4rem);
+            margin: 0 0 0.75rem;
+            letter-spacing: -0.03em;
+        }
+
+        p.description {
+            margin: 0 0 1.75rem;
+            line-height: 1.55;
+            color: rgba(240, 246, 252, 0.75);
+        }
+
+        .control-group {
+            display: grid;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+
+        label {
+            font-weight: 600;
+            font-size: 0.95rem;
+            display: block;
+        }
+
+        input[type="text"] {
+            width: 100%;
+            padding: 0.9rem 1rem;
+            border-radius: 12px;
+            border: 1px solid rgba(88, 166, 255, 0.25);
+            background: rgba(13, 17, 23, 0.75);
+            color: var(--text);
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        input[type="text"]:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(56, 139, 253, 0.25);
+        }
+
+        button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            padding: 0.9rem 1.4rem;
+            border-radius: 999px;
+            border: none;
+            background: linear-gradient(135deg, var(--accent) 0%, var(--accent-dark) 100%);
+            color: #fff;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        button:hover:not([disabled]) {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 30px rgba(31, 111, 235, 0.28);
+        }
+
+        button:disabled {
+            opacity: 0.65;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        .review-card {
+            margin-top: 1.5rem;
+            padding: 1.5rem;
+            border-radius: 16px;
+            background: rgba(13, 17, 23, 0.7);
+            border: 1px solid rgba(88, 166, 255, 0.18);
+            min-height: 140px;
+            display: grid;
+            gap: 0.8rem;
+        }
+
+        .review-text {
+            font-size: 1.05rem;
+            line-height: 1.6;
+            color: rgba(240, 246, 252, 0.9);
+            word-break: break-word;
+        }
+
+        .sentiment-display {
+            display: flex;
+            align-items: center;
+            gap: 0.8rem;
+            font-size: 1.1rem;
+            font-weight: 600;
+        }
+
+        .sentiment-icon {
+            width: 42px;
+            height: 42px;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.45rem;
+            background: rgba(88, 166, 255, 0.12);
+        }
+
+        .sentiment-icon.positive {
+            color: var(--positive);
+            background: rgba(46, 160, 67, 0.12);
+        }
+
+        .sentiment-icon.negative {
+            color: var(--negative);
+            background: rgba(248, 81, 73, 0.12);
+        }
+
+        .sentiment-icon.neutral {
+            color: var(--neutral);
+            background: rgba(210, 153, 34, 0.12);
+        }
+
+        .status, .error-message {
+            margin-top: 1rem;
+            font-size: 0.95rem;
+        }
+
+        .error-message {
+            color: var(--error);
+            min-height: 1.2rem;
+        }
+
+        .status {
+            color: rgba(240, 246, 252, 0.75);
+            min-height: 1.2rem;
+        }
+
+        footer {
+            margin-top: 2rem;
+            font-size: 0.85rem;
+            color: rgba(240, 246, 252, 0.6);
+            text-align: center;
+        }
+
+        @media (max-width: 520px) {
+            .card {
+                padding: 2rem 1.4rem;
+            }
+
+            .review-card {
+                padding: 1.2rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="card" aria-live="polite">
+        <h1>Random Review Sentiment Explorer</h1>
+        <p class="description">Analyze random product reviews from a curated dataset using Hugging Face's sentiment model. Provide your optional API token to boost rate limits, then discover how customers really feel.</p>
+        <div class="control-group">
+            <label for="token-input">Hugging Face API Token (optional)</label>
+            <input type="text" id="token-input" name="token-input" placeholder="hf_..." autocomplete="off">
+            <button id="analyze-btn" type="button" disabled>
+                <i class="fa-solid fa-shuffle" aria-hidden="true"></i>
+                Analyze Random Review
+            </button>
+        </div>
+        <section class="review-card">
+            <div class="review-text" id="review-text">Loading reviews…</div>
+            <div class="sentiment-display" id="sentiment-display" hidden>
+                <span class="sentiment-icon" id="sentiment-icon" aria-hidden="true"></span>
+                <span id="sentiment-label"></span>
+            </div>
+        </section>
+        <div class="status" id="status-message"></div>
+        <div class="error-message" id="error-message"></div>
+        <footer>Model: siebert/sentiment-roberta-large-english • Powered by Hugging Face Inference API</footer>
+    </main>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-8sGAvFp8ZUBKbjDgq09uXBJgp7wa9u0edPFpKnz03Wx/ju0RduCMsZ/HXXIQK5vCk1vZ1tcHTfb3e8DqnuMqVg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="app.js" defer></script>
+</body>
+</html>

--- a/reviews_test.tsv
+++ b/reviews_test.tsv
@@ -1,0 +1,11 @@
+text
+"This wireless charger is a lifesaver for travel and powers up my phone incredibly fast."
+"The blender broke after two uses and customer support never responded to my emails."
+"Comfortable headphones with crisp audio but the battery life could be a bit longer."
+"I love how intuitive the smart thermostat is and my energy bill has dropped noticeably."
+"The laptop arrived with a dead pixel and the return process was confusing and slow."
+"Great camera quality for the price point, though the low-light performance is average."
+"Absolutely disappointed—the vacuum lost suction within a week of light use."
+"The coffee maker's scheduling feature makes mornings effortless and tastes great."
+"Packaging was damaged on arrival but the speaker still works and sounds decent."
+"Setup was simple and the tablet runs all my apps smoothly without hiccups."


### PR DESCRIPTION
## Summary
- build a responsive interface to explore random product reviews
- integrate Papa Parse and Hugging Face sentiment model with optional token support
- add a curated TSV dataset of example review texts for analysis

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caec1bdc308330852e67a0993596fa